### PR TITLE
Allow shell_handler position to be set by Telescope

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,9 +107,10 @@ A customizable Neovim plugin to run code inside the editor
 
     Runs a command in a shell by opening it in a new split window, with a terminal buffer.
 
-
     The split window's position will be determined by the `position` value from the config. It will be overwritten when using the telescope mapping to open horizontally or vertically.
-
+    - `select_horizontal` (defaults to `<C-X>`): Opens the window at the bottom of the screen.
+    - `select_vertical` (defaults to `<C-V>`): Opens the window at the right of the screen.
+    <br/>
 
     | Argument name | Description | Type |
     |---------------- | --------------- | --------------- |

--- a/README.md
+++ b/README.md
@@ -66,7 +66,9 @@ A customizable Neovim plugin to run code inside the editor
   Runner comes with the following defaults:
   ```lua
   require('runner').setup({
-    position = 'right', -- position of the terminal window when using the shell_handler - can be: top, left, right, bottom
+    position = 'right', -- position of the terminal window when using the shell_handler
+                        -- can be: top, left, right, bottom
+                        -- will be overwritten when using the telescope mapping to open horizontally or vertically
     width = 80,         -- width of window when position is left or right
     height = 10,        -- height of window when position is top or bottom
   })
@@ -104,7 +106,11 @@ A customizable Neovim plugin to run code inside the editor
   - #### `shell_handler(command, editable)`
 
     Runs a command in a shell by opening it in a new split window, with a terminal buffer.
-    
+
+
+    The split window's position will be determined by the `position` value from the config. It will be overwritten when using the telescope mapping to open horizontally or vertically.
+
+
     | Argument name | Description | Type |
     |---------------- | --------------- | --------------- |
     | `command` | The shell command to run when the handler is called | `string` |

--- a/lua/runner/handlers/helpers.lua
+++ b/lua/runner/handlers/helpers.lua
@@ -63,23 +63,23 @@ M.choice = function(handlers)
           end)
           actions.select_horizontal:replace(function()
             local default_position = config.options.position
-            config.options.position = 'bottom';
+            config.options.position = 'bottom'
 
             actions.close(prompt_bufnr)
             local handler_name = action_state.get_selected_entry()[1]
             handlers[handler_name](buffer)
 
-            config.options.position = default_position;
+            config.options.position = default_position
           end)
           actions.select_vertical:replace(function()
             local default_position = config.options.position
-            config.options.position = 'top';
+            config.options.position = 'top'
 
             actions.close(prompt_bufnr)
             local handler_name = action_state.get_selected_entry()[1]
             handlers[handler_name](buffer)
 
-            config.options.position = default_position;
+            config.options.position = default_position
           end)
           return true
         end,

--- a/lua/runner/handlers/helpers.lua
+++ b/lua/runner/handlers/helpers.lua
@@ -5,6 +5,7 @@ local action_state = require('telescope.actions.state')
 local sorters = require('telescope.sorters')
 local themes = require('telescope.themes')
 
+local config = require('runner.config')
 local utils = require('runner.handlers.utils')
 
 local M = {}
@@ -59,6 +60,26 @@ M.choice = function(handlers)
             actions.close(prompt_bufnr)
             local handler_name = action_state.get_selected_entry()[1]
             handlers[handler_name](buffer)
+          end)
+          actions.select_horizontal:replace(function()
+            local default_position = config.options.position
+            config.options.position = 'bottom';
+
+            actions.close(prompt_bufnr)
+            local handler_name = action_state.get_selected_entry()[1]
+            handlers[handler_name](buffer)
+
+            config.options.position = default_position;
+          end)
+          actions.select_vertical:replace(function()
+            local default_position = config.options.position
+            config.options.position = 'top';
+
+            actions.close(prompt_bufnr)
+            local handler_name = action_state.get_selected_entry()[1]
+            handlers[handler_name](buffer)
+
+            config.options.position = default_position;
           end)
           return true
         end,


### PR DESCRIPTION
You can now use Telescope actions to specify the `shell_handler`'s window position
- `select_horizontal` (defaults to `<C-X>`): Opens the window at the bottom of the screen
- `select_vertical` (defaults to `<C-V>`): Opens the window at the right of the screen